### PR TITLE
Update awscli-install-bundle.md

### DIFF
--- a/doc-source/awscli-install-bundle.md
+++ b/doc-source/awscli-install-bundle.md
@@ -15,7 +15,7 @@ The bundled installer does not support installing to paths that contain spaces\.
 
 + Linux, macOS, or Unix
 
-+ Python 2 version 2\.6\.5\+ or Python 3 version 3\.3\+
++ Python 2 version 2\.7\+ or Python 3 version 3\.3\+
 
 Check your Python installation:
 


### PR DESCRIPTION
[root@ip-10-32-21-113 awscli-bundle]# ./install -i /usr/local/aws -b /usr/local/bin/aws
Running cmd: /usr/bin/python virtualenv.py --no-download --python /usr/bin/python /usr/local/aws
Running cmd: /usr/local/aws/bin/pip install --no-index --find-links file:///root/awscli-bundle/packages awscli-1.14.54.tar.gz
Traceback (most recent call last):
  File "./install", line 143, in <module>
    main()
  File "./install", line 132, in main
    pip_install_packages(opts.install_dir)
  File "./install", line 100, in pip_install_packages
    pip_script, PACKAGES_DIR, cli_tarball))
  File "./install", line 45, in run
    p.returncode, cmd, stdout + stderr))
__main__.BadRCError: Bad rc (1) for cmd '/usr/local/aws/bin/pip install --no-index --find-links file:///root/awscli-bundle/packages awscli-1.14.54.tar.gz': Processing ./awscli-1.14.54.tar.gz
Collecting botocore==1.9.7 (from awscli==1.14.54)
Collecting colorama<=0.3.7,>=0.2.5 (from awscli==1.14.54)
Collecting docutils>=0.10 (from awscli==1.14.54)
Collecting rsa<=3.5.0,>=3.1.2 (from awscli==1.14.54)
Collecting s3transfer<0.2.0,>=0.1.12 (from awscli==1.14.54)
Collecting PyYAML<=3.12,>=3.10 (from awscli==1.14.54)
Requirement already satisfied: argparse>=1.1 in /usr/local/aws/lib/python2.6/site-packages (from awscli==1.14.54)
Collecting jmespath<1.0.0,>=0.7.1 (from botocore==1.9.7->awscli==1.14.54)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore==1.9.7->awscli==1.14.54)
**DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
python-dateutil requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*' but the running Python is 2.6.6**

[root@ip-10-32-21-113 awscli-bundle]#

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
